### PR TITLE
remove url from logging

### DIFF
--- a/src/EventGridExtension/EventGridExtensionConfig.cs
+++ b/src/EventGridExtension/EventGridExtensionConfig.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                 SubscriptionValidationResponse validationResponse = new SubscriptionValidationResponse { ValidationResponse = validationEvent.ValidationCode };
                 var returnMessage = new HttpResponseMessage(HttpStatusCode.OK);
                 returnMessage.Content = new StringContent(JsonConvert.SerializeObject(validationResponse));
-                _logger.LogInformation($"perform handshake with eventGrid for endpoint: {req.RequestUri}");
+                _logger.LogInformation($"perform handshake with eventGrid for function: {functionName}");
                 return returnMessage;
             }
             else if (String.Equals(eventTypeHeader, "Notification", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
this is used to log handshake requests sent from eventGrid, but the full url contains too much information (ie the code parameter)