### PR TITLE
add support for cloud event schema

### DIFF
--- a/src/EventGridExtension/EventGridExtensionConfig.cs
+++ b/src/EventGridExtension/EventGridExtensionConfig.cs
@@ -87,12 +87,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             }
             else if (String.Equals(eventTypeHeader, "Notification", StringComparison.OrdinalIgnoreCase))
             {
-                string jsonArray = await req.Content.ReadAsStringAsync();
-                List<JObject> events = JsonConvert.DeserializeObject<List<JObject>>(jsonArray);
-                List<Task<FunctionResult>> executions = new List<Task<FunctionResult>>();
+                JArray events = null;
+                string requestContent = await req.Content.ReadAsStringAsync();
+                var token = JToken.Parse(requestContent);
+                if (token.Type == JTokenType.Array)
+                {
+                    // eventgrid schema
+                    events = (JArray)token;
+                }
+                else if (token.Type == JTokenType.Object)
+                {
+                    // cloudevent schema
+                    events = new JArray
+                    {
+                        token
+                    };
+                }
 
+                List<Task<FunctionResult>> executions = new List<Task<FunctionResult>>();
                 foreach (var ev in events)
                 {
+                    // assume each event is a JObject
                     TriggeredFunctionData triggerData = new TriggeredFunctionData
                     {
                         TriggerValue = ev

--- a/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
+++ b/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
 
                 var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
                 {
+                    // if triggerValue does not have data property, this will be null
                     { "data", triggerValue["data"] }
                 };
 

--- a/test/Extension.tests/Common/FakeData.cs
+++ b/test/Extension.tests/Common/FakeData.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Common
 {
     public static class FakeData
     {
-        public const string arrayOfOneEvent = @"[{
+        public const string eventGridEvents = @"[{
   'topic': '/subscriptions/5b4b650e-28b9-4790-b3ab-ddbd88d727c4/resourcegroups/canaryeh/providers/Microsoft.EventHub/namespaces/canaryeh',
   'subject': 'eventhubs/test',
   'eventType': 'captureFileCreated',
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Common
   'metadataVersion': '1'
 }]";
 
-        public const string singleEvent = @"{
+        public const string eventGridEvent = @"{
   'topic': '/subscriptions/5b4b650e-28b9-4790-b3ab-ddbd88d727c4/resourcegroups/canaryeh/providers/Microsoft.EventHub/namespaces/canaryeh',
   'subject': 'eventhubs/test',
   'eventType': 'captureFileCreated',
@@ -43,6 +43,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Common
   },
   'dataVersion': '',
   'metadataVersion': '1'
+}";
+
+        // https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/event-grid/cloudevents-schema.md#cloudevent-schema
+
+        public const string cloudEvent = @"{
+    'cloudEventsVersion' : '0.1',
+    'eventType' : 'Microsoft.Storage.BlobCreated',
+    'eventTypeVersion' : '',
+    'source' : '/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.Storage/storageAccounts/{storage-account}#blobServices/default/containers/{storage-container}/blobs/{new-file}',
+    'eventID' : '173d9985-401e-0075-2497-de268c06ff25',
+    'eventTime' : '2018-04-28T02:18:47.1281675Z',
+    'data' : {
+      'api': 'PutBlockList',
+      'clientRequestId': '6d79dbfb-0e37-4fc4-981f-442c9ca65760',
+      'requestId': '831e1650-001e-001b-66ab-eeb76e000000',
+      'eTag': '0x8D4BCC2E4835CD0',
+      'contentType': 'application/octet-stream',
+      'contentLength': 524288,
+      'blobType': 'BlockBlob',
+      'url': 'https://oc2d2817345i60006.blob.core.windows.net/oc2d2817345i200097container/oc2d2817345i20002296blob',
+      'sequencer': '00000000000004420000000000028963',
+      'storageDiagnostics': {
+        'batchId': 'b68529f3-68cd-4744-baa4-3c0498ec19f0'
+      }
+    }
 }";
 
         public const string stringDataEvent = @"{
@@ -78,6 +103,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Common
   'metadataVersion': '1'
 }";
 
+        public const string missingDataEvent = @"{
+  'topic': '/subscriptions/5b4b650e-28b9-4790-b3ab-ddbd88d727c4/resourcegroups/canaryeh/providers/Microsoft.EventHub/namespaces/canaryeh',
+  'subject': 'eventhubs/test',
+  'eventType': 'captureFileCreated',
+  'eventTime': '2017-07-14T23:10:27.7689666Z',
+  'id': '7b11c4ce-1c34-4416-848b-1730e766f126',
+  'dataVersion': '',
+  'metadataVersion': '1'
+}";
     }
 
 }

--- a/test/Extension.tests/JobhostEndToEnd.cs
+++ b/test/Extension.tests/JobhostEndToEnd.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         public async Task ConsumeEventGridEventTest()
         {
 
-            JObject eve = JObject.Parse(FakeData.singleEvent);
+            JObject eve = JObject.Parse(FakeData.eventGridEvent);
             var args = new Dictionary<string, object>{
                 { "value", eve }
             };
@@ -37,46 +37,58 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         }
 
         [Fact]
+        public async Task ConsumeCloudEventTest()
+        {
+            JObject eve = JObject.Parse(FakeData.cloudEvent);
+            var args = new Dictionary<string, object>{
+                { "value", eve }
+            };
+
+            var expectOut = (string)eve["eventType"];
+
+            var host = TestHelpers.NewHost<MyProg2>();
+
+            await host.CallAsync("MyProg2.TestCloudEventToString", args);
+            Assert.Equal(functionOut, expectOut);
+            functionOut = null;
+
+            await host.CallAsync("MyProg2.TestCloudEventToJObject", args);
+            Assert.Equal(functionOut, expectOut);
+            functionOut = null;
+        }
+
+        [Fact]
         public async Task ValidJsonBindingDataTests()
         {
             var host = TestHelpers.NewHost<MyProg3>();
 
-            JObject eve = JObject.Parse(FakeData.singleEvent);
             var args = new Dictionary<string, object>{
-                { "value", eve }
+                { "value", JObject.Parse(FakeData.eventGridEvent) }
             };
 
             await host.CallAsync("MyProg3.TestJObject", args);
             Assert.Equal(@"https://shunsouthcentralus.blob.core.windows.net/debugging/shunBlob.txt", functionOut);
             functionOut = null;
 
-            eve = JObject.Parse(FakeData.stringDataEvent);
-            args = new Dictionary<string, object>{
-                { "value", eve }
-            };
-
+            args["value"] = JObject.Parse(FakeData.stringDataEvent);
             await host.CallAsync("MyProg3.TestString", args);
             Assert.Equal("goodBye world", functionOut);
             functionOut = null;
 
-            eve = JObject.Parse(FakeData.arrayDataEvent);
-            args = new Dictionary<string, object>{
-                { "value", eve }
-            };
-
+            args["value"] = JObject.Parse(FakeData.arrayDataEvent);
             await host.CallAsync("MyProg3.TestArray", args);
             Assert.Equal("ConfusedDev", functionOut);
             functionOut = null;
 
-            eve = JObject.Parse(FakeData.primitiveDataEvent);
-            args = new Dictionary<string, object>{
-                { "value", eve }
-            };
-
+            args["value"] = JObject.Parse(FakeData.primitiveDataEvent);
             await host.CallAsync("MyProg3.TestPrimitive", args);
             Assert.Equal("123", functionOut);
             functionOut = null;
 
+            args["value"] = JObject.Parse(FakeData.missingDataEvent);
+            await host.CallAsync("MyProg3.TestDataFieldMissing", args);
+            Assert.Equal("", functionOut);
+            functionOut = null;
         }
 
         public class MyProg1
@@ -98,6 +110,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             }
         }
 
+        public class MyProg2
+        {
+            public void TestCloudEventToString([EventGridTrigger] string value)
+            {
+                functionOut = (string)JObject.Parse(value)["eventType"];
+            }
+
+            public void TestCloudEventToJObject([EventGridTrigger] JObject value)
+            {
+                functionOut = (string)value["eventType"];
+            }
+
+        }
+
         public class MyProg3
         {
             public void TestJObject(
@@ -112,6 +138,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
                 [BindingData("{data}")] string autoResolve)
             {
                 functionOut = autoResolve;
+            }
+
+            public void TestDataFieldMissing(
+                [EventGridTrigger] JObject value,
+                [BindingData("{data}")] string autoResovle)
+            {
+                functionOut = autoResovle;
             }
 
             // auto resolve only works for string

--- a/test/Extension.tests/UnitTests.cs
+++ b/test/Extension.tests/UnitTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             ParameterInfo[] arrayParam = methodbase.GetParameters();
 
             ITriggerBinding binding = new EventGridTriggerBinding(arrayParam[0], null);
-            JObject eve = JObject.Parse(FakeData.singleEvent);
+            JObject eve = JObject.Parse(FakeData.eventGridEvent);
             JObject data = (JObject)eve["data"];
 
             // JObject as input
@@ -30,12 +30,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             Assert.Equal(data, triggerDataWithEvent.BindingData["data"]);
 
             // string as input
-            ITriggerData triggerDataWithString = await binding.BindAsync(FakeData.singleEvent, null);
+            ITriggerData triggerDataWithString = await binding.BindAsync(FakeData.eventGridEvent, null);
             Assert.Equal(data, triggerDataWithString.BindingData["data"]);
 
             // test invalid, batch of events
-            FormatException formatException = await Assert.ThrowsAsync<FormatException>(() => binding.BindAsync(FakeData.arrayOfOneEvent, null));
-            Assert.Equal($"Unable to parse {FakeData.arrayOfOneEvent} to {typeof(JObject)}", formatException.Message);
+            FormatException formatException = await Assert.ThrowsAsync<FormatException>(() => binding.BindAsync(FakeData.eventGridEvents, null));
+            Assert.Equal($"Unable to parse {FakeData.eventGridEvents} to {typeof(JObject)}", formatException.Message);
 
             // test invalid, random object
             var testObject = new TestClass();


### PR DESCRIPTION
code change is very simple:
```
if (token.Type == JTokenType.Array)
{
	// eventgrid schema
	events = (JArray)token;
}
else if (token.Type == JTokenType.Object)
{
	// cloudevent schema
	events = new JArray
	{
		token
	};
}
```
the rest is change in tests